### PR TITLE
Centralize navigation items

### DIFF
--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -4,6 +4,15 @@ import Image from 'next/image';
 import Link from 'next/link';
 import { Menu, X } from 'lucide-react';
 
+export const NAV_ITEMS = [
+  { label: 'Accueil', href: '/' },
+  { label: 'Carte', href: '/carte' },
+  { label: 'Statistiques', href: '#' },
+  { label: 'Échanges', href: '#' },
+  { label: 'Contact', href: '#' },
+  { label: 'À propos', href: '#' },
+];
+
 interface HeaderProps {
   menuOpen: boolean;
   setMenuOpen: (open: boolean) => void;
@@ -19,12 +28,11 @@ export default function Header({ menuOpen, setMenuOpen }: HeaderProps) {
 
       {/* Desktop Menu */}
       <nav className="hidden md:flex gap-6 text-sm font-medium text-gray-700">
-        <Link href="/">Accueil</Link>
-        <Link href="/carte">Carte</Link>
-        <Link href="#">Statistiques</Link>
-        <Link href="#">Échanges</Link>
-        <Link href="#">Contact</Link>
-        <Link href="#">À propos</Link>
+        {NAV_ITEMS.map(({ href, label }) => (
+          <Link key={href} href={href}>
+            {label}
+          </Link>
+        ))}
       </nav>
 
       <div className="hidden md:flex items-center gap-4">

--- a/components/pages/home/HomePage.tsx
+++ b/components/pages/home/HomePage.tsx
@@ -6,7 +6,7 @@ import { useState } from 'react';
 import clsx from 'clsx';
 import HeroHeader from './HeroHeader';
 import StatsSection from './StatsSection';
-import Header from '../../layout/Header';
+import Header, { NAV_ITEMS } from '../../layout/Header';
 import Footer from '../../layout/Footer';
 
 export default function HomePage() {
@@ -23,12 +23,15 @@ export default function HomePage() {
         menuOpen ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none'
       )}>
         <nav className="flex flex-col items-center gap-6">
-          <Link href="/" onClick={() => setMenuOpen(false)}>Accueil</Link>
-          <Link href="/carte" onClick={() => setMenuOpen(false)}>Carte</Link>
-          <Link href="#" onClick={() => setMenuOpen(false)}>Statistiques</Link>
-          <Link href="#" onClick={() => setMenuOpen(false)}>Échanges</Link>
-          <Link href="#" onClick={() => setMenuOpen(false)}>Contact</Link>
-          <Link href="#" onClick={() => setMenuOpen(false)}>À propos</Link>
+          {NAV_ITEMS.map(({ href, label }) => (
+            <Link
+              key={href}
+              href={href}
+              onClick={() => setMenuOpen(false)}
+            >
+              {label}
+            </Link>
+          ))}
         </nav>
         <div className="flex flex-col items-center gap-2 mt-6">
           <Link href="/login" className="text-green-800 text-sm font-medium">Connexion</Link>


### PR DESCRIPTION
## Summary
- export `NAV_ITEMS` from `Header`
- render desktop and mobile links from that array

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879673c5264832a87feeb40a03b517e