### PR TITLE
Add global layout elements

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,9 +1,48 @@
+'use client';
+
 import '../styles/globals.css';
+import { useState } from 'react';
+import Link from 'next/link';
+import clsx from 'clsx';
+import Header, { NAV_ITEMS } from '@/components/layout/Header';
+import Footer from '@/components/layout/Footer';
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
+  const [menuOpen, setMenuOpen] = useState(false);
+
   return (
     <html lang="fr">
-      <body>{children}</body>
+      <body className="bg-[#f7f1e4] text-gray-900">
+        <Header menuOpen={menuOpen} setMenuOpen={setMenuOpen} />
+        <div
+          className={clsx(
+            'fixed inset-0 bg-[#f7f1e4] flex flex-col items-center justify-center gap-6 text-lg text-gray-800 z-40 transition-opacity duration-300',
+            menuOpen ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none'
+          )}
+        >
+          <nav className="flex flex-col items-center gap-6">
+            {NAV_ITEMS.map(({ href, label }) => (
+              <Link key={href} href={href} onClick={() => setMenuOpen(false)}>
+                {label}
+              </Link>
+            ))}
+          </nav>
+          <div className="flex flex-col items-center gap-2 mt-6">
+            <Link href="/login" className="text-green-800 text-sm font-medium" onClick={() => setMenuOpen(false)}>
+              Connexion
+            </Link>
+            <Link
+              href="/signup"
+              className="bg-green-700 text-white text-sm font-semibold px-5 py-2 rounded-full hover:bg-green-800"
+              onClick={() => setMenuOpen(false)}
+            >
+              Créer un compte
+            </Link>
+          </div>
+        </div>
+        <div className="pt-20 min-h-screen flex flex-col">{children}</div>
+        <Footer />
+      </body>
     </html>
   );
 }

--- a/components/pages/home/HomePage.tsx
+++ b/components/pages/home/HomePage.tsx
@@ -1,44 +1,13 @@
 // app/page.tsx
 'use client';
 
-import Link from 'next/link';
-import { useState } from 'react';
-import clsx from 'clsx';
 import HeroHeader from './HeroHeader';
 import StatsSection from './StatsSection';
-import Header, { NAV_ITEMS } from '../../layout/Header';
-import Footer from '../../layout/Footer';
 
 export default function HomePage() {
-  const [menuOpen, setMenuOpen] = useState(false);
 
   return (
     <main className="flex flex-col min-h-screen bg-[#f7f1e4] text-gray-900">
-      {/* Header with logo and menu */}
-      <Header menuOpen={menuOpen} setMenuOpen={setMenuOpen} />
-
-      {/* Mobile full-screen menu */}
-      <div className={clsx(
-        'fixed inset-0 bg-[#f7f1e4] flex flex-col items-center justify-center gap-6 text-lg text-gray-800 z-40 transition-opacity duration-300',
-        menuOpen ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none'
-      )}>
-        <nav className="flex flex-col items-center gap-6">
-          {NAV_ITEMS.map(({ href, label }) => (
-            <Link
-              key={href}
-              href={href}
-              onClick={() => setMenuOpen(false)}
-            >
-              {label}
-            </Link>
-          ))}
-        </nav>
-        <div className="flex flex-col items-center gap-2 mt-6">
-          <Link href="/login" className="text-green-800 text-sm font-medium">Connexion</Link>
-          <Link href="/signup" className="bg-green-700 text-white text-sm font-semibold px-5 py-2 rounded-full hover:bg-green-800">Créer un compte</Link>
-        </div>
-      </div>
-
       <div className="pt-20">
         {/* Hero Section */}
         <HeroHeader />
@@ -72,8 +41,6 @@ export default function HomePage() {
           </div>
         </section>
 
-        {/* Footer */}
-        <Footer />
       </div>
     </main>
   );


### PR DESCRIPTION
## Summary
- provide Header and Footer in the root layout so every page has them
- clean up HomePage to remove duplicate layout elements

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_687971afe5ec832abce633b0c1d47611