### PR TITLE
Use API_BASE helper for API requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# Cultiviso Front
+
+This repository contains the front-end built with Next.js and Tailwind CSS.
+
+## Environment variables
+
+The application expects a running API. Configure the API base URL with the following variable:
+
+```
+NEXT_PUBLIC_API_BASE_URL=http://localhost:3001
+```
+
+It is read at runtime to build API requests. Existing calls also use `NEXT_PUBLIC_API_KEY` if your API requires it.
+
+Create a `.env.local` file at the project root to set these variables before running the app.

--- a/components/pages/carte/CarteComponent.tsx
+++ b/components/pages/carte/CarteComponent.tsx
@@ -9,6 +9,7 @@ import { useEffect, useRef, useState } from 'react';
 import bbox from '@turf/bbox';
 import booleanOverlap from '@turf/boolean-overlap';
 import * as turf from '@turf/helpers';
+import { API_BASE } from '@/lib/api';
 
 
 interface Culture {
@@ -75,11 +76,11 @@ export default function CarteComponent() {
   const API_KEY = process.env.NEXT_PUBLIC_API_KEY;
 
   useEffect(() => {
-    fetch('http://localhost:3001/v1/cultures', {
+    fetch(`${API_BASE}/v1/cultures`, {
       headers: { 'X-api-key': `${API_KEY}` },
     }).then(res => res.json()).then(setCultures);
 
-    fetch('http://localhost:3001/v1/cultures/years', {
+    fetch(`${API_BASE}/v1/cultures/years`, {
       headers: { 'X-api-key': `${API_KEY}` },
     }).then(res => res.json()).then(setYears);
   }, []);
@@ -99,7 +100,7 @@ export default function CarteComponent() {
     if (!selectedYear || !selectedCulture || !mapRef.current) return;
 
     const map = mapRef.current;
-    const url = `http://localhost:3001/v1/stats/regions?year=${selectedYear}&cultureId=${selectedCulture}`;
+    const url = `${API_BASE}/v1/stats/regions?year=${selectedYear}&cultureId=${selectedCulture}`;
 
     fetch(url, {
       headers: { 'X-api-key': `${API_KEY}` },

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -1,0 +1,1 @@
+export const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL;


### PR DESCRIPTION
## Summary
- add `API_BASE` helper in `lib/api.ts`
- use `API_BASE` in CarteComponent instead of hardcoded URL
- document `NEXT_PUBLIC_API_BASE_URL` in new README

## Testing
- `npm run build` *(fails: `next` not found)*
- `npm install` *(fails: could not fetch packages)*

------
https://chatgpt.com/codex/tasks/task_e_6879737a610c832a9d8b1c86383fb1ec