### PR TITLE
Fix .gitignore typo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,7 +38,7 @@ Thumbs.db
 # Local exports
 *.sqlite
 *.zip
-*.tar.gznode_modules
+*.tar.gz
 
 # Temporary files
 *.tmp


### PR DESCRIPTION
## Summary
- fix typo in `.gitignore`
- ensure file ends with a newline

## Testing
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_687976c569e0832ab2f93a79ce0ed7ef