### PR TITLE
Fix map preview aspect ratio

### DIFF
--- a/components/pages/home/CartePreview.tsx
+++ b/components/pages/home/CartePreview.tsx
@@ -33,10 +33,17 @@ export default function CartePreview() {
     mapRef.current = new maplibregl.Map({
       container: mapContainer.current,
       style: 'https://basemaps.cartocdn.com/gl/voyager-gl-style/style.json',
-      center: [2.2137, 46.2276],
-      zoom: 5,
+      interactive: false,
       attributionControl: false,
     });
+
+    mapRef.current.fitBounds(
+      [
+        [-5.9, 41.2],
+        [9.6, 51.2],
+      ],
+      { padding: 0, duration: 0 }
+    );
 
     const API_KEY = process.env.NEXT_PUBLIC_API_KEY;
 

--- a/components/pages/home/StatsSection.tsx
+++ b/components/pages/home/StatsSection.tsx
@@ -5,7 +5,7 @@ export default function StatsSection() {
     <section className="py-16 px-6 text-center">
       <h2 className="text-2xl font-bold mb-4">Une vue d'ensemble du territoire</h2>
       <p className="text-gray-600 mb-8">+100 000 hectares analysés • +50 cultures référencées • Données publiques consolidées</p>
-       <div className="w-full max-w-4xl h-64 mx-auto bg-gray-200 rounded-lg shadow-inner">
+       <div className="w-full max-w-4xl aspect-square mx-auto bg-gray-200 rounded-lg shadow-inner">
         <CartePreview />
       </div>
     </section>


### PR DESCRIPTION
## Summary
- square the map preview container in home page to center on France
- show only the static map of France

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ab7d6eda8832a85cba6f0e355ff74