### PR TITLE
Add chart selection tabs

### DIFF
--- a/app/stats/page.tsx
+++ b/app/stats/page.tsx
@@ -18,6 +18,7 @@ import {
 } from 'chart.js';
 import { Line, Bar, Pie, Doughnut, Radar, PolarArea, Scatter, Bubble } from 'react-chartjs-2';
 import { API_BASE } from '@/lib/api';
+import ChartTabs, { TabOption } from '@/components/pages/stats/ChartTabs';
 
 ChartJS.register(
   CategoryScale,
@@ -64,6 +65,7 @@ export default function StatsPage() {
   const [selectedCulture, setSelectedCulture] = useState<string>('');
   const [selectedRegion, setSelectedRegion] = useState<string>('');
   const [stats, setStats] = useState<StatItem[]>([]);
+  const [selectedChart, setSelectedChart] = useState<string>('line');
 
   const API_KEY = process.env.NEXT_PUBLIC_API_KEY;
 
@@ -178,6 +180,18 @@ export default function StatsPage() {
     }]
   };
 
+  const chartTabs: TabOption[] = [
+    { id: 'line', label: 'Ligne' },
+    { id: 'bar', label: 'Barres' },
+    { id: 'pie', label: 'Secteurs' },
+    { id: 'doughnut', label: 'Donut' },
+    { id: 'radar', label: 'Radar' },
+    { id: 'polar', label: 'Polar' },
+    { id: 'scatter', label: 'Nuage' },
+    { id: 'bubble', label: 'Bulles' },
+    { id: 'barh', label: 'Barres H' },
+  ];
+
   return (
     <div className="p-4 space-y-8">
       <div className="flex flex-wrap gap-4">
@@ -215,17 +229,18 @@ export default function StatsPage() {
           ))}
         </select>
       </div>
-      <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-1 gap-3">
-        <Line data={lineData} />
-        <Bar data={barData} />
-        <Pie data={pieData} />
-        <Doughnut data={doughnutData} />
-        <Radar data={radarData} />
-        <PolarArea data={polarData} />
-        <Scatter data={scatterData} />
-        <Bubble data={bubbleData} />
-        <Bar data={barData} options={{ indexAxis: 'y' as const }} />
-        </div>
+      <ChartTabs tabs={chartTabs} selected={selectedChart} onSelect={setSelectedChart} />
+      <div className="w-full max-w-3xl mx-auto">
+        {selectedChart === 'line' && <Line data={lineData} />}
+        {selectedChart === 'bar' && <Bar data={barData} />}
+        {selectedChart === 'pie' && <Pie data={pieData} />}
+        {selectedChart === 'doughnut' && <Doughnut data={doughnutData} />}
+        {selectedChart === 'radar' && <Radar data={radarData} />}
+        {selectedChart === 'polar' && <PolarArea data={polarData} />}
+        {selectedChart === 'scatter' && <Scatter data={scatterData} />}
+        {selectedChart === 'bubble' && <Bubble data={bubbleData} />}
+        {selectedChart === 'barh' && <Bar data={barData} options={{ indexAxis: 'y' as const }} />}
       </div>
+    </div>
   );
 }

--- a/components/pages/stats/ChartTabs.tsx
+++ b/components/pages/stats/ChartTabs.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import { cn } from '@/lib/utils';
+
+export interface TabOption {
+  id: string;
+  label: string;
+}
+
+interface ChartTabsProps {
+  tabs: TabOption[];
+  selected: string;
+  onSelect: (id: string) => void;
+}
+
+export default function ChartTabs({ tabs, selected, onSelect }: ChartTabsProps) {
+  return (
+    <div className="flex gap-2 border-b mb-4 overflow-x-auto">
+      {tabs.map(tab => (
+        <button
+          key={tab.id}
+          onClick={() => onSelect(tab.id)}
+          className={cn(
+            'px-3 py-1 text-sm rounded-t-md border',
+            selected === tab.id
+              ? 'bg-white border-b-0 font-semibold'
+              : 'bg-gray-100'
+          )}
+        >
+          {tab.label}
+        </button>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- create `ChartTabs` component for selecting analytics charts
- switch stats page to show one chart at a time with tab navigation

## Testing
- `npm run build` *(fails: cannot run build in environment)*

------
https://chatgpt.com/codex/tasks/task_e_688a84d21a44832ab7e080e15f66cf95