### PR TITLE
feat: adjust indicator tabs layout

### DIFF
--- a/components/pages/stats/IndicatorTabs.tsx
+++ b/components/pages/stats/IndicatorTabs.tsx
@@ -17,13 +17,13 @@ interface IndicatorTabsProps {
 
 export default function IndicatorTabs({ tabs, selected, onSelect }: IndicatorTabsProps) {
   return (
-    <div className="flex flex-col gap-2">
+    <div className="flex flex-row md:flex-col gap-2">
       {tabs.map(({ id, label, icon: Icon }) => (
         <button
           key={id}
           onClick={() => onSelect(id)}
           className={cn(
-            'flex items-center gap-2 px-3 py-2 border-l-4 rounded-l-md text-sm',
+            'flex items-center gap-2 px-3 py-2 text-sm border-b-4 md:border-b-0 md:border-l-4 rounded-b-md md:rounded-l-md',
             selected === id ? 'bg-white border-primary font-semibold' : 'bg-gray-100 border-transparent'
           )}
         >


### PR DESCRIPTION
## Summary
- display indicator tabs horizontally on small screens and vertically from md breakpoint
- update tab styling to use bottom borders for horizontal layout

## Testing
- `npm run build` (fails: next: not found)
- `npm install` (fails: ENOTEMPTY: directory not empty)


------
https://chatgpt.com/codex/tasks/task_e_688bd53cbcac832aab9e485db789f90b