### PR TITLE
Add reCAPTCHA to signup form

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Create a `.env.local` file in the project root and set these variables:
 ```bash
 NEXT_PUBLIC_API_BASE_URL=http://localhost:3001
 NEXT_PUBLIC_API_KEY=your_api_key_if_required
+NEXT_PUBLIC_RECAPTCHA_SITE_KEY=your_recaptcha_site_key
 ```
 
 These values are read at runtime to build API requests.

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -2,6 +2,7 @@
 'use client';
 
 import { useState } from 'react';
+import ReCAPTCHA from 'react-google-recaptcha';
 import { useRouter } from 'next/navigation';
 import Image from 'next/image';
 import { Button } from '@/components/ui/button';
@@ -15,6 +16,7 @@ export default function SignupPage() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
+  const [recaptchaToken, setRecaptchaToken] = useState<string | null>(null);
 
   const handleSignup = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -25,7 +27,7 @@ export default function SignupPage() {
             headers: { 'Accept': 'application/json',
             'Content-Type': 'application/json',
             'X-api-key': `${API_KEY}` },
-            body: JSON.stringify({ firstName, lastName, email, password }),
+            body: JSON.stringify({ firstName, lastName, email, password, recaptchaToken }),
         });
 
       if (res.ok) {
@@ -94,6 +96,12 @@ export default function SignupPage() {
           </div>
 
           {error && <p className="text-sm text-red-500 mt-2">{error}</p>}
+
+          <ReCAPTCHA
+            sitekey={process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY || ''}
+            onChange={(token) => setRecaptchaToken(token)}
+            className="mt-4"
+          />
 
           <Button
             type="submit"

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-icons": "^5.5.0",
+    "react-google-recaptcha": "^2.1.0",
     "chart.js": "^4.4.0",
     "react-chartjs-2": "^5.0.0"
   },


### PR DESCRIPTION
## Summary
- add react-google-recaptcha dependency
- render reCAPTCHA on signup and include token in register request
- document site key env variable

## Testing
- `npm install react-google-recaptcha` (fails: 403)
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_689114546b50832a9290172f28409f01