### PR TITLE
Protect stats and map pages with auth guard

### DIFF
--- a/app/carte/page.tsx
+++ b/app/carte/page.tsx
@@ -1,11 +1,14 @@
 'use client';
 
 import CarteComponent from '@/components/pages/carte/CarteComponent';
+import ProtectedRoute from '@/components/auth/ProtectedRoute';
 
 export default function CartePage() {
   return (
-    <main className="h-screen">
-      <CarteComponent />
-    </main>
+    <ProtectedRoute>
+      <main className="h-screen">
+        <CarteComponent />
+      </main>
+    </ProtectedRoute>
   );
 }

--- a/app/stats/page.tsx
+++ b/app/stats/page.tsx
@@ -22,6 +22,7 @@ import { API_BASE, API_KEY } from '@/lib/api';
 import ChartTabs, { TabOption } from '@/components/pages/stats/ChartTabs';
 import IndicatorTabs, { IndicatorTabOption } from '@/components/pages/stats/IndicatorTabs';
 import { FiLayers, FiTrendingUp, FiPackage } from 'react-icons/fi';
+import ProtectedRoute from '@/components/auth/ProtectedRoute';
 
 ChartJS.register(
   CategoryScale,
@@ -61,7 +62,7 @@ interface StatItem {
   productionT: number;
 }
 
-export default function StatsPage() {
+function StatsContent() {
   const [cultures, setCultures] = useState<Culture[]>([]);
   const [years, setYears] = useState<number[]>([]);
   const [regions, setRegions] = useState<Region[]>([]);
@@ -304,5 +305,13 @@ export default function StatsPage() {
         </div>
       </div>
     </div>
+  );
+}
+
+export default function StatsPage() {
+  return (
+    <ProtectedRoute>
+      <StatsContent />
+    </ProtectedRoute>
   );
 }

--- a/components/auth/ProtectedRoute.tsx
+++ b/components/auth/ProtectedRoute.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { ReactNode, useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+
+interface ProtectedRouteProps {
+  children: ReactNode;
+}
+
+export default function ProtectedRoute({ children }: ProtectedRouteProps) {
+  const router = useRouter();
+  const [authorized, setAuthorized] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    const token = typeof window !== 'undefined' ? localStorage.getItem('token') : null;
+    if (!token) {
+      router.push('/signup');
+      setAuthorized(false);
+    } else {
+      setAuthorized(true);
+    }
+  }, [router]);
+
+  if (authorized === null) {
+    return null;
+  }
+
+  if (!authorized) {
+    return <p className="p-4">Access denied</p>;
+  }
+
+  return <>{children}</>;
+}


### PR DESCRIPTION
## Summary
- add reusable `ProtectedRoute` to check for a token and redirect unauthenticated users
- wrap stats and map pages with `ProtectedRoute` so only logged in users can view them

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@types%2fnode)*

------
https://chatgpt.com/codex/tasks/task_e_689507849998832a8f0fceffa1cf69a9