### PR TITLE
feat: show feedback for notification preferences

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -133,14 +133,21 @@ export default function DashboardPage() {
           marketplace: notifyMarketplace,
         }),
       });
+      const data = await res.json().catch(() => null);
       if (res.ok) {
-        setSaveMessage({ type: 'success', text: 'Préférences enregistrées.' });
+        setSaveMessage({
+          type: 'success',
+          text: data?.message || 'Préférences enregistrées.',
+        });
       } else {
-        setSaveMessage({ type: 'error', text: "Une erreur est survenue." });
+        setSaveMessage({
+          type: 'error',
+          text: data?.message || 'Une erreur est survenue.',
+        });
       }
     } catch (err) {
       console.error(err);
-      setSaveMessage({ type: 'error', text: "Une erreur est survenue." });
+      setSaveMessage({ type: 'error', text: 'Une erreur est survenue.' });
     } finally {
       setSavingNotifications(false);
     }


### PR DESCRIPTION
## Summary
- handle error and success responses when saving notification preferences
- show a confirmation or error message after saving

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689a5f526204832a9d12e62087142009