### PR TITLE
feat: add admin route protection

### DIFF
--- a/app/admin/users/page.tsx
+++ b/app/admin/users/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import ProtectedRoute from '@/components/auth/ProtectedRoute';
+import AdminRoute from '@/components/auth/AdminRoute';
 import { API_BASE, API_KEY } from '@/lib/api';
 
 interface User {
@@ -40,7 +40,7 @@ export default function AdminUsersPage() {
   const hasNext = users.length === limit; // naive check
 
   return (
-    <ProtectedRoute>
+    <AdminRoute>
       <div className="p-4 space-y-4">
         <h1 className="text-2xl font-bold mb-4">Utilisateurs</h1>
         <div className="overflow-x-auto">
@@ -111,6 +111,6 @@ export default function AdminUsersPage() {
           </div>
         </div>
       </div>
-    </ProtectedRoute>
+    </AdminRoute>
   );
 }

--- a/components/auth/AdminRoute.tsx
+++ b/components/auth/AdminRoute.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import { ReactNode, useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { API_BASE, API_KEY } from '@/lib/api';
+
+interface AdminRouteProps {
+  children: ReactNode;
+}
+
+export default function AdminRoute({ children }: AdminRouteProps) {
+  const router = useRouter();
+  const [authorized, setAuthorized] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    const token = typeof window !== 'undefined' ? localStorage.getItem('token') : null;
+    if (!token) {
+      router.push('/login');
+      setAuthorized(false);
+      return;
+    }
+
+    fetch(`${API_BASE}/v1/auth/me`, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'X-api-key': API_KEY || '',
+      },
+    })
+      .then(res => {
+        if (!res.ok) throw new Error('Unauthorized');
+        return res.json();
+      })
+      .then(data => {
+        if (data?.role === 'admin' || data?.isAdmin) {
+          setAuthorized(true);
+        } else {
+          router.push('/dashboard');
+          setAuthorized(false);
+        }
+      })
+      .catch(() => {
+        router.push('/login');
+        setAuthorized(false);
+      });
+  }, [router]);
+
+  if (authorized === null) {
+    return null;
+  }
+
+  if (!authorized) {
+    return <p className="p-4">Accès refusé</p>;
+  }
+
+  return <>{children}</>;
+}
+


### PR DESCRIPTION
## Summary
- add AdminRoute component to verify admin status via `/v1/auth/me`
- guard admin users page with AdminRoute

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: 403 Forbidden fetching @types/node)*

------
https://chatgpt.com/codex/tasks/task_e_689ba174b380832aa12527f2a4673df6